### PR TITLE
Fix Python 3 setup on non-UTF-8 systems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,12 @@
 from setuptools import setup, find_packages
+from io import open
 from os import path
 import re
 
 
 VERSION = re.search("VERSION = '([^']+)'", open(
-    path.join(path.dirname(__file__), 'webencodings', '__init__.py')
+    path.join(path.dirname(__file__), 'webencodings', '__init__.py'),
+    encoding='utf-8'
 ).read().strip()).group(1)
 
 LONG_DESCRIPTION = open(path.join(path.dirname(__file__), 'README.rst')).read()

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 from setuptools import setup, find_packages
-from io import open
+import io
 from os import path
 import re
 
 
-VERSION = re.search("VERSION = '([^']+)'", open(
+VERSION = re.search("VERSION = '([^']+)'", io.open(
     path.join(path.dirname(__file__), 'webencodings', '__init__.py'),
     encoding='utf-8'
 ).read().strip()).group(1)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,10 @@ VERSION = re.search("VERSION = '([^']+)'", io.open(
     encoding='utf-8'
 ).read().strip()).group(1)
 
-LONG_DESCRIPTION = open(path.join(path.dirname(__file__), 'README.rst')).read()
+LONG_DESCRIPTION = io.open(
+    path.join(path.dirname(__file__), 'README.rst'),
+    encoding='utf-8'
+).read()
 
 
 setup(

--- a/webencodings/__init__.py
+++ b/webencodings/__init__.py
@@ -185,7 +185,7 @@ def encode(input, encoding=UTF8, errors='strict'):
 
 def iter_decode(input, fallback_encoding, errors='replace'):
     """
-    “Pull”-based decoder.
+    "Pull"-based decoder.
 
     :param input:
         An iterable of byte strings.


### PR DESCRIPTION
`setup.py` was opening `webencodings/__init__.py` using the system 8-bit encoding, so not UTF-8 on Windows. This change is compatible with Python 2.6 and 2.7.