### PR TITLE
Use 'utf-8' as encoding instead of 'utf8'

### DIFF
--- a/webencodings/__init__.py
+++ b/webencodings/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
 
     webencodings

--- a/webencodings/tests.py
+++ b/webencodings/tests.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
 
     webencodings.tests

--- a/webencodings/x_user_defined.py
+++ b/webencodings/x_user_defined.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
 
     webencodings.x_user_defined


### PR DESCRIPTION
This should fix #8 by changing the encoding of `webencodings` source files to `utf-8` which seems to be a more widely accepted identifier by 3rd party tools (namely, `xgettext`).