### PR TITLE
Include license file in the distributed files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [bdist_wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE
+
 [build_sphinx]
 source-dir = docs
 build-dir  = docs/_build


### PR DESCRIPTION
Use MANIFEST.in to include LICENSE in the generated source distribution.

The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file

Fixes #12