### PR TITLE
Add build directory to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.egg-info
 .coverage
 docs/_build
-/dist
+/build/
+/dist/
 htmlcov


### PR DESCRIPTION
The directory is created when building wheel distributions.