### PR TITLE
Use an explicit test matrix for Travis to get Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,23 @@
 language: python
-python: 3.4
-
 sudo: false
-
 cache: pip
 
-env:
-  - TOXENV=py26
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=pypy
-
-# Hack around the Travis CI image not containing 3.5 by default
 matrix:
   include:
+    - python: 2.6
+      env: TOXENV=py26
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
     - python: 3.5
-      env:
-        - TOXENV=py35
+      env: TOXENV=py35
     - python: 3.6
-      env:
-        - TOXENV=py36
+      env: TOXENV=py36
+    - python: pypy
+      env: TOXENV=pypy
 
 install:
   - pip install -U tox


### PR DESCRIPTION
Not all python versions are available in the default testing image. Instruct Travis to make the necessary Python version available in the test matrix.

Fixes Travis test failures.