### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ This is a Python implementation of the `WHATWG Encoding standard
 * Latest documentation: http://packages.python.org/webencodings/
 * Source code and issue tracker:
   https://github.com/gsnedders/python-webencodings
-* PyPI releases: http://pypi.python.org/pypi/webencodings
+* PyPI releases: https://pypi.org/project/webencodings/
 * License: BSD
 * Python 2.6+ and 3.3+
 


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html