### PR TITLE
Move tests out of package; no longer installed to site-packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include tests.py

--- a/tests.py
+++ b/tests.py
@@ -13,8 +13,9 @@
 
 from __future__ import unicode_literals
 
-from . import (lookup, LABELS, decode, encode, iter_decode, iter_encode,
-               IncrementalDecoder, IncrementalEncoder, UTF8)
+from webencodings import (lookup, LABELS, decode, encode, iter_decode,
+                          iter_encode, IncrementalDecoder, IncrementalEncoder,
+                          UTF8)
 
 
 def assert_raises(exception, function, *args, **kwargs):


### PR DESCRIPTION
Tests are no longer unnecessarily installed to users site-packages
directory. Tests are still included in the source distribution.