### PR TITLE
Add CI for Python 3.7, 3.8, 3.9, 3.10 & pypy-3.7 via GitHub actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,31 @@
+name: Build and test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U tox
+      - name: Run tox
+        # Run tox using the version of Python in `PATH`
+        run: tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 python_files=test*.py
 
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, pypy
+envlist = py37, py38, py39, py3.10, pypy3.7
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
Add CI (via GitHub Actions) to test against currently supported versions of Python 3.

[A successful CI run looks like this](https://github.com/wellmaintained/python-webencodings/actions/runs/2185596064):

![image](https://user-images.githubusercontent.com/227505/163863014-9b4be202-fd78-4ebc-a330-6b410607b96f.png)
